### PR TITLE
Add functional scripts to the repository

### DIFF
--- a/make-pangenome-sketches.py
+++ b/make-pangenome-sketches.py
@@ -1,8 +1,10 @@
 #! /usr/bin/env python
+
 import argparse
 import sys
-
-from collections import defaultdict
+from collections import Counter, defaultdict
+import csv
+import os
 import sourmash
 from sourmash import sourmash_args
 from sourmash.tax import tax_utils
@@ -21,17 +23,25 @@ def main():
     )
     p.add_argument('--scaled', default=1000, type=int)
     p.add_argument('-k', '--ksize', default=31, type=int)
-    p.add_argument('-o', '--output', required=True)
+    p.add_argument('-o', '--output', required=True,
+                    help='Define a filename for the pangenome signatures (.zip preferred). \n'
+                         'A CSV file with the same name will also be generated to contain the lineage rank, genome name, and hash count.')
     p.add_argument('-r', '--rank', default='species')
+    p.add_argument('-a', '--abund', action='store_true', help='Enable abundance tracking of hashes across rank selection.')
     args = p.parse_args()
 
     print(f"loading taxonomies from {args.taxonomy_file}")
     taxdb = sourmash.tax.tax_utils.MultiLineageDB.load(args.taxonomy_file)
     print(f"found {len(taxdb)} identifiers in taxdb.")
 
-    revtax_d = {}
     ident_d = {}
+    revtax_d = {}
+    accum = defaultdict(dict)
+    if args.abund:
+        counts = {}
+    csv_file = check_csv(args.output)
 
+    # Load the database
     for filename in args.sketches:
         print(f"loading file {filename} as index => manifest")
         db = sourmash_args.load_file_as_index(filename)
@@ -39,15 +49,15 @@ def main():
         mf = db.manifest
         assert mf, "no matching sketches for given ksize!?"
 
-        # load and merge
+        chunk = []
+        # Work on a single signature at a time across the database
         for n, ss in enumerate(db.signatures()):
             if n and n % 1000 == 0:
                 print(f'...{n} - loading')
+
             name = ss.name
-            md5sum = ss.md5sum()
-
             ident = tax_utils.get_ident(name)
-
+            
             # grab relevant lineage name
             lineage_tup = taxdb[ident]
             lineage_tup = tax_utils.RankLineageInfo(lineage=lineage_tup)
@@ -55,18 +65,46 @@ def main():
             lineage_name = lineage_pair[-1].name
 
             # pick an ident to represent this set of pangenome sketches
-            ident_d[lineage_name] = ident # ok if overwrite...
+            ident_d[lineage_name] = ident 
+
+            # Accumulate the count within lineage names if `--abund` in cli
+            if args.abund:
+                c = Counter(ss.minhash.hashes)
+                if lineage_name in counts:
+                    counts[lineage_name].update(c)
+                else:
+                    counts[lineage_name] = c
 
             # track merged sketches
             mh = revtax_d.get(lineage_name)
             if mh is None:
                 mh = ss.minhash.to_mutable()
+            
                 revtax_d[lineage_name] = mh
             else:
                 mh += ss.minhash
 
+            # Accumulated counts of hashes in lineage by genome
+            hash_count = len(mh.hashes)
+            
+            ## Add {name, hash_count} to a lineage key then
+            ## create a simpler dict for writing the csv
+            accum[lineage_name][name] = accum[lineage_name].get(name, 0) + hash_count
+            chunk.append({'lineage': lineage_name, 'sig_name': name, 'hash_count': hash_count})
+            
+            if len(chunk) >= 1000: #args.chunk_size?
+                write_chunk(chunk, csv_file) #args.outputfilenameforcsv?
+                accum = defaultdict(dict)
+                chunk = []
 
-    # save!
+        # Write remaining data
+        if chunk:
+            write_chunk(chunk, csv_file)
+            accum = defaultdict(dict)
+            chunk = []
+
+
+   # save!
     with sourmash_args.SaveSignaturesToLocation(args.output) as save_sigs:
         for n, (lineage_name, ident) in enumerate(ident_d.items()):
             if n and n % 1000 == 0:
@@ -76,12 +114,33 @@ def main():
             # retrieve merged MinHash
             mh = revtax_d[lineage_name]
 
-            # make a signature
-            ss = sourmash.SourmashSignature(mh, name=sig_name)
+            # Add abundance to signature if `--abund` in cli
+            if args.abund:
+                abund_d = dict(counts[lineage_name])
+                
+                abund_mh = mh.copy_and_clear()
+                abund_mh.track_abundance = True
+                abund_mh.set_abundances(abund_d)
 
-            # save!
-            save_sigs.add(ss)
+            # Create a signature with abundance only if `abund` in cli. Otherwise, create a 'flat' sig
+            ss = sourmash.SourmashSignature(abund_mh, name=sig_name) if args.abund else sourmash.SourmashSignature(mh, name=sig_name)
 
+            save_sigs.add(ss)            
+
+# Chunk function to limit the memory used by the hash_count dict and list
+def write_chunk(chunk, output_file):
+    with open(output_file, 'a', newline='') as csvfile:
+        fieldnames = ['lineage', 'sig_name', 'hash_count']
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writerows(chunk)
+
+def check_csv(csv_file):
+    count_csv = os.path.splitext(csv_file)[0] + ".csv"
+
+    if os.path.exists(count_csv):
+        raise argparse.ArgumentTypeError("\n%s already exists" % count_csv)
+
+    return count_csv
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/scripts/diff_csv.py
+++ b/scripts/diff_csv.py
@@ -1,0 +1,55 @@
+#! /usr/bin/env python
+
+import argparse
+from process_csv import pangenome_csv
+
+
+def counting_kmers(data, lineage):
+    lineage_list = {}
+    lineage = lineage
+
+    for d in data:
+        l = d['lineage']
+        hash_count = int(d['hash_count'])
+        genome_count = int(d['genome_count'])
+
+        if l not in lineage_list:
+            lineage_list[l] = {}
+
+        if genome_count not in lineage_list[l]:
+            lineage_list[l][genome_count] = hash_count  # Store as single integer
+        else:
+            lineage_list[l][genome_count] += hash_count  # Accumulate hash count if already exists
+
+
+    sorted_genome_counts = sorted(lineage_list[lineage].keys())
+    differences = []
+
+    for index in range(len(sorted_genome_counts)-1):
+        genome_count1 = sorted_genome_counts[index]
+        genome_count2 = sorted_genome_counts[index+1]
+        hash_counts1 = lineage_list[lineage].get(genome_count1, 0)
+        hash_counts2 = lineage_list[lineage].get(genome_count2, 0)
+        difference = hash_counts2 - hash_counts1
+        differences.append(difference)
+
+    differences.insert(0, [v for v in lineage_list[lineage].values()][0]) #slap the first genome kmer count on the front
+
+    #for i in range(5):
+    #    print(f"In {lineage}, genome {i} has {differences[i]} new kmers.")
+    return differences, lineage, lineage_list
+
+p = argparse.ArgumentParser(description='Gather difference data from lineage counts')
+p.add_argument('data', metavar='CSV_DATA', help='This is the processed CSV data from the pangenome CSV file')
+p.add_argument('-l', '--lineage', metavar='LINEAGE_STRING', help='This is the lineage name to isolate from the dataset')
+args = p.parse_args()
+
+#pangenome_csv(args.filename)
+#counting_kmers(args.data, args.lineage)
+# Call pangenome_csv to process the CSV file
+csv_data = pangenome_csv(args.data)
+
+# Call counting_kmers with the processed CSV data
+diff, lineage, lineage_list = counting_kmers(csv_data, args.lineage)
+
+#diff, lineage, lineage_list = counting_kmers(csv_data, 's__Escherichia coli')

--- a/scripts/plot_diff.py
+++ b/scripts/plot_diff.py
@@ -1,0 +1,37 @@
+#! /usr/bin/env python
+
+import argparse
+import matplotlib
+from process_csv import pangenome_csv, gather_difference
+
+def plot_novels(data, line_width=1, marker='none', yaxis='kmers', scaled=1000):
+    plt.figure(figsize=(12,5))
+    if yaxis=="hashes":
+        plt.plot(range(len(data)), data, linewidth=line_width, marker=marker) #marker='o' for circles
+    elif yaxis=="kmers":
+        plt.plot(range(len(data)), [i * scaled for i in diff], linewidth=line_width, marker=marker)
+    else:
+        print("Invalid value for yaxis. Defaulting to 'kmers'.")
+        plt.plot(range(len(data)), [i * scaled for i in diff], linewidth=line_width, marker=marker)
+    plt.gca().spines['top'].set_visible(False)
+    plt.gca().spines['right'].set_visible(False)
+    plt.xlabel('New Genomes')
+    if yaxis=="hashes":
+        plt.ylabel('Novel hashes')
+        plt.title(f'Novel pangenome hashes per genome for Lineage: {lineage}')
+    elif yaxis=="kmers":
+        plt.ticklabel_format(style='sci', axis='y', scilimits=(0,0), useMathText=True)
+        plt.ylabel('Novel k-mers')
+        plt.title(f'Novel pangenome k-mers per genome for Lineage: {lineage}')
+    else:
+        #print("Invalid value for yaxis. Defaulting to 'kmers'.")
+        plt.ylabel('Novel k-mers')
+        plt.title(f'Novel pangenome k-mers per genome for Lineage: {lineage}')
+    plt.show()
+
+csv_data = pangenome_csv(args.filename)
+diff = gather_difference(csv_data, args.lineage)
+
+plot_novels(data = diff, line_width=0.65, marker='_', yaxis='hashes')
+plot_novels(data = diff, line_width=0.65, marker='o', yaxis='kmers')
+plot_novels(data = diff, line_width=0.65, yaxis='kmes')

--- a/scripts/process_csv.py
+++ b/scripts/process_csv.py
@@ -1,0 +1,72 @@
+#! /usr/bin/env python
+
+import argparse
+import csv
+
+
+def pangenome_csv(filename):
+    total_rows = sum(1 for line in open(filename))
+    processed_rows = 0
+    csv_data = []
+    fieldnames = ['lineage', 'sig_name', 'hash_count', 'genome_count']
+    
+    try:
+        with open(filename, newline = '') as fp:
+            csv_file = csv.DictReader(fp, fieldnames)
+            for row in csv_file:
+                processed_rows += 1
+                if processed_rows % 1000 == 0:
+                    print(f"Processed {processed_rows}/{total_rows} rows ({processed_rows/total_rows*100:.2f}% complete)", end='\r', flush=True)
+                
+                csv_data.append(dict(row))
+            print(' ' * 80) # or "\n"?
+            print(f"Pangenome CSV file contained {total_rows} rows.")
+            print(f"Processing of {processed_rows} rows has been completed.\n")
+            return csv_data
+    except Exception as e:
+        print(f"An error occurred: {str(e)}")
+
+
+def gather_difference(data, lineage):
+    lineage_list = {}
+    lineage = lineage
+
+    for d in data:
+        l = d['lineage']
+        hash_count = int(d['hash_count'])
+        genome_count = int(d['genome_count'])
+
+        if l not in lineage_list:
+            lineage_list[l] = {}
+
+        if genome_count not in lineage_list[l]:
+            lineage_list[l][genome_count] = hash_count  # Store as single integer
+        else:
+            lineage_list[l][genome_count] += hash_count  # Accumulate hash count if already exists
+
+    sorted_genome_counts = sorted(lineage_list[lineage].keys())
+    differences = []
+
+    for index in range(len(sorted_genome_counts) - 1):
+        genome_count1 = sorted_genome_counts[index]
+        genome_count2 = sorted_genome_counts[index + 1]
+        hash_counts1 = lineage_list[lineage].get(genome_count1, 0)
+        hash_counts2 = lineage_list[lineage].get(genome_count2, 0)
+        difference = hash_counts2 - hash_counts1
+        differences.append(difference)
+
+    differences.insert(0, [v for v in lineage_list[lineage].values()][0])  # Slap the first genome kmer count on the front
+
+    for i in range(5):
+        print(f"In {lineage}, genome {i} has {differences[i]} new kmers.")
+
+    return differences, lineage, lineage_list
+
+
+p = argparse.ArgumentParser(description='Process a pangenome CSV file.')
+p.add_argument('filename', metavar='CSV', help='This is the pangenome CSV file to process')
+p.add_argument('-l', '--lineage', metavar='LINEAGE_STRING', help='This is the lineage name to isolate from the dataset')
+args = p.parse_args()
+
+csv_data = pangenome_csv(args.filename)
+gather_difference(csv_data, args.lineage)

--- a/simple-use-case.md
+++ b/simple-use-case.md
@@ -299,3 +299,76 @@ rank family:              4814 distinct taxonomic lineages
 rank genus:               20739 distinct taxonomic lineages
 rank species:             85205 distinct taxonomic lineages
 ```
+
+Comparing species level pangenome with representative genomes of GTDB
+
+Representative Database:
+```
+== This is sourmash version 4.8.5. ==
+== Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==
+
+** loading from '/group/ctbrowngrp/sourmash-db/gtdb-rs214/gtdb-rs214-reps.k21.zip'
+path filetype: ZipFileLinearIndex
+location: /group/ctbrowngrp/sourmash-db/gtdb-rs214/gtdb-rs214-reps.k21.zip
+is database? yes
+has manifest? yes
+num signatures: 85205
+** examining manifest...
+total hashes: 270637876
+summary of sketches:
+   85205 sketches with DNA, k=21, scaled=1000         270637876 total hashes
+```
+
+Species Database:
+```
+== This is sourmash version 4.8.5. ==
+== Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==
+
+** loading from 'gtdb-rs214-k21.pangenomes.species.zip'
+path filetype: ZipFileLinearIndex
+location: /home/baumlerc/2022-database-covers/gtdb-rs214-k21.pangenomes.species.zip
+is database? yes
+has manifest? yes
+num signatures: 85205
+** examining manifest...
+total hashes: 326393008
+summary of sketches:
+   85205 sketches with DNA, k=21, scaled=1000         326393008 total hashes
+```
+
+## Explore the impact of database on `sourmash gather`
+
+Download the metadata at [this SRA Run Selector link](https://www.ncbi.nlm.nih.gov/Traces/study/?acc=SRR1976948%2CSRR5650070%2CSRR606249%2CSRR12324253&o=acc_s%3Aa)
+
+I renamed my SraRunTable.txt to mock.txt.
+
+For Farm HPC users:
+
+1. Check if signature files already exist on the Farm.
+```
+for i in $(awk -F',' 'NR >= 2 {print $1}' mock.txt | uniq); do echo [ -e "/group/ctbrowngrp/irber/data/wort-data/wort-sra/sigs/$i.sig" ] && echo "File $i.sig exists in wort" || echo "File $i.sig does not exist in wort" ; done
+```
+
+2. Link those files into the `sigs` directory for ease and minimal disk space use.
+```
+for i in $(awk -F',' 'NR > 1 {print $1}' mock.txt); do ln -s /group/ctbrowngrp/irber/data/wort-data/wort-sra/sigs/$i.sig $(pwd)/sigs/$i.sig ; done
+```
+
+> - Note that each of these bash conditionals were written with `echo` after `do` in the for loop. This output shows the action the for loop will execute before I unleash it on the computer cluster.
+> This:
+> ```
+> for i in $(awk -F',' 'NR > 1 {print $1}' mock.txt); do echo ln -s /group/ctbrowngrp/irber/data/wort-data/wort-sra/sigs/$i.sig $(pwd)/sigs/$i.sig ; done
+> ```
+> Outputs:
+> ```
+> ln -s /group/ctbrowngrp/irber/data/wort-data/wort-sra/sigs/SRR606249.sig /home/baumlerc/2022-database-covers/sigs/SRR606249.sig
+> ln -s /group/ctbrowngrp/irber/data/wort-data/wort-sra/sigs/SRR5650070.sig /home/baumlerc/2022-database-covers/sigs/SRR5650070.sig
+> ln -s /group/ctbrowngrp/irber/data/wort-data/wort-sra/sigs/SRR1976948.sig /home/baumlerc/2022-database-covers/sigs/SRR1976948.sig
+> ln -s /group/ctbrowngrp/irber/data/wort-data/wort-sra/sigs/SRR12324253.sig /home/baumlerc/2022-database-covers/sigs/SRR12324253.sig
+> ```
+
+Running `sourmash prefetch` on mock metagenome signatures
+```
+sourmash prefetch --threshold-bp 3000 -o prefetch/SRR12324253-prefetch.csv -k 21 sigs/SRR12324253.sig gtdb-rs214-k21.pangenomes.species.zip
+```
+[Should threshold be set to 3x scaled as a minimum](https://sourmash.readthedocs.io/en/latest/faq.html#id8)


### PR DESCRIPTION
This pull request is adding scripts to process the data output from the pangenome branch ( #10 ). That branch outputs a sourmash database and a csv containing:
| Lineage                              | Sig Name                                                                   | Hash Count | Genome Count |
|---|:---:|:---:|:---:|
| s__Bacillus_A anthracis             | GCA_000006155.2 Bacillus anthracis str. A2012 strain=A2012, ASM615v2        | 5308       | 0            |
| s__Fusobacterium nucleatum          | GCA_000007325.1 Fusobacterium nucleatum subsp. nucleatum ATCC 25586 strain=ATCC 25586, ASM732v1 | 2139       | 1            |
| s__Xanthomonas oryzae               | GCA_000007385.1 Xanthomonas oryzae pv. oryzae KACC 10331 strain=KACC10331, ASM738v1 | 4300       | 2            |
| s__Nanoarchaeum equitans            | GCA_000008085.1 Nanoarchaeum equitans Kin4-M, ASM808v1                      | 503        | 3            |
| s__Helicobacter pylori              | GCA_000008525.1 Helicobacter pylori 26695 strain=26695, ASM852v1            | 1701       | 4            |
| s__Wigglesworthia glossinidia_A     | GCA_000008885.1 Wigglesworthia glossinidia endosymbiont of Glossina brevipalpis, ASM888v1 | 706        | 5            |
| s__Phytoplasma sp000009845          | GCA_000009845.1 Onion yellows phytoplasma OY-M strain=onion yellows, ASM984v1 | 746        | 6            |
| s__Pelotomaculum thermopropionicum  | GCA_000010565.1 Pelotomaculum thermopropionicum SI strain=SI, ASM1056v1     | 2992       | 7            |
| s__Azobacteroides pseudotrichonymphae_B | GCA_000010645.1 Candidatus Azobacteroides pseudotrichonymphae genomovar. CFP2, ASM1064v1 | 1145 | 8            |
| s__Mycoplasma mycoides              | GCA_000011445.1 Mycoplasma mycoides subsp. mycoides SC str. PG1 strain=PG1, ASM1144v1 | 942 | 9            |
