### PR TITLE
[MRG] Minor fixes for downstream scripts

### DIFF
--- a/scripts/classify-hashes.py
+++ b/scripts/classify-hashes.py
@@ -64,7 +64,19 @@ def main():
             print(f"\t {count} ({percent:.1f}%) hashes are classified as {name}")
 
         count = counter_d.get(-1, 0)
-        print(f"\t ...and {count} hashes are NOT IN the csv file")
+        classified_total_count = 0
+        for (k,v) in counter_d.items():
+            if k >= 0:
+                classified_total_count += v
+
+        total_count = 0
+        for (k,v) in counter_d.items(): total_count += v 
+        assert total_count > 0
+
+        percent = count / total_count * 100
+
+        print(f"\t ...and {classified_total_count} ({classified_total_count/total_count*100:.1f}%) hashes are in the {csv_file}")
+        print(f"\t ...and {count} ({percent:.1f}%) hashes are NOT IN the {csv_file}")
 
         core_ss = sourmash.SourmashSignature(central_core_mh, name='core')
         with SaveSignaturesToLocation('core.sig.gz') as save_sig:

--- a/scripts/pangenome_elements.py
+++ b/scripts/pangenome_elements.py
@@ -59,7 +59,7 @@ def main():
                    help='CSV file containing classification of each hash')
     args = p.parse_args()
 
-    ss_dict = db_process(filename=args.data, k=args.ksize, lineage_name=args.lineage, ignore_case=args.ignore_case, invert_match=False)
+    ss_dict = db_process(filename=args.data, k=args.ksize, lineage_name=args.lineage, ignore_case=args.ignore_case)
     results = pangenome_elements(data=ss_dict)
 
     if args.output_hash_classification:

--- a/scripts/process_ss.py
+++ b/scripts/process_ss.py
@@ -8,7 +8,7 @@ import os
 import re
 
 
-def db_process(filename, ignore_case, invert_match, user_input, process_db, k=31, lineage_name='None'):
+def db_process(filename, ignore_case=False, invert_match=False, user_input=False, process_db=False, k=31, lineage_name='None'):
     bname = os.path.basename(filename)
     ss_dict = {}
     print(f"\nloading file {bname} as index => manifest")


### PR DESCRIPTION
`classify_hsahes.py` now outputs:
```
$ ./classify-hashes.py ERR1293497.sig.gz fuso.csv -k 21
For 'fuso.csv', signature 'ERR1293497' contains:
         4 (13.8%) hashes are classified as central core
         2 (6.9%) hashes are classified as external core
         14 (48.3%) hashes are classified as shell
         9 (31.0%) hashes are classified as inner cloud
         0 (0.0%) hashes are classified as surface cloud
         ...and 29 (0.0%) hashes are in the fuso.csv
         ...and 275094 (100.0%) hashes are NOT IN the fuso.csv
```

`process_ss.py` core function's arguments are not set to False to prevent them from being listed every time the function is called.